### PR TITLE
Fix compile errors on rust-nightly

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,5 +1,5 @@
 #![crate_type="dylib"]
-#![feature(plugin_registrar)]
+#![feature(plugin_registrar, slice_patterns)]
 #![feature(rustc_private, core)]
 #![deny(warnings)]
 #![allow(unused_features)]

--- a/src/bin/glassful.rs
+++ b/src/bin/glassful.rs
@@ -1,12 +1,13 @@
-#![feature(old_io)]
 #![deny(warnings)]
-
-use std::old_io as io;
 
 extern crate glassful;
 
+use std::io;
+use std::io::Read;
+
 pub fn main() {
-    let prog = io::stdin().read_to_end().unwrap();
-    let prog = String::from_utf8(prog).unwrap();
-    print!("{}", glassful::translate(prog));
+    let mut prog = String::new();
+    if io::stdin().read_to_string(&mut prog).is_ok() {
+        print!("{}", glassful::translate(prog));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(rustc_private)]
+#![feature(rustc_private, slice_patterns)]
 #![deny(warnings)]
 
 extern crate syntax;


### PR DESCRIPTION
 Add slice_syntax to rust feature attributes, and move glassful binary to std::io from std::old_io
